### PR TITLE
Fix for measuring on mobile devices

### DIFF
--- a/gwt-ol3-client/src/main/java/ol/gwt/Measure.java
+++ b/gwt-ol3-client/src/main/java/ol/gwt/Measure.java
@@ -52,7 +52,7 @@ public class Measure extends Interaction {
     private Draw draw;
 
     private HandlerRegistration clickListener;
-    
+
     private MeasureListener listener;
 
     private HandlerRegistration pointerMoveListener;

--- a/gwt-ol3-client/src/main/java/ol/gwt/Measure.java
+++ b/gwt-ol3-client/src/main/java/ol/gwt/Measure.java
@@ -51,6 +51,8 @@ public class Measure extends Interaction {
 
     private Draw draw;
 
+    private HandlerRegistration clickListener;
+    
     private MeasureListener listener;
 
     private HandlerRegistration pointerMoveListener;
@@ -235,7 +237,14 @@ public class Measure extends Interaction {
                 }
 
             });
+            // this handler is necessary to support mobile devices without a mouse
+            this.clickListener = this.getMap().addClickListener((MapBrowserEvent event) -> {
 
+                if (this.draw.getActive()) {
+                    this.fireMeasureEvent();
+                }
+
+            });
         }
 
     }
@@ -284,6 +293,9 @@ public class Measure extends Interaction {
             this.draw = null;
         }
 
+        if (this.clickListener != null) {
+            this.clickListener.removeHandler();
+        }
         if (this.pointerMoveListener != null) {
             this.pointerMoveListener.removeHandler();
         }


### PR DESCRIPTION
Fix for measuring on mobile devices (like iPads) if immediate flag is set.

As mobile devices do not generate mouse move events, we need to track the click event, which gets generated (even on touch devices).
It does not harm for desktop devices as those get a lot of measure events for every mouse move anyway.

@TDesjardins : The draw interaction in OpenLayers seems ok so far and there is no other possibility to get the changed geometry than to use a `click` event on the map. This interaction just changes the coordinates in the geometry of the sketch feature and these coordinates are a plain JavaScript array, which does not trigger any events.