### PR TITLE
Add some missing function from openlayers API

### DIFF
--- a/gwt-ol3-client/src/main/java/ol/geom/Geometry.java
+++ b/gwt-ol3-client/src/main/java/ol/geom/Geometry.java
@@ -137,4 +137,21 @@ public abstract class Geometry extends Observable {
      */
     public native boolean intersectsCoordinate(Coordinate coordinate);
 
+    /**
+     * Scale the geometry (with an optional origin). This modifies the geometry coordinates in place.
+     *
+     * @param scaleX The scaling factor in the x-direction.
+     * @param scaleY The scaling factor in the y-direction.
+     */
+    public native void scale(double scaleX, double scaleY);
+
+    /**
+     * Scale the geometry (with an optional origin). This modifies the geometry coordinates in place.
+     *
+     * @param scaleX The scaling factor in the x-direction.
+     * @param scaleY The scaling factor in the y-direction.
+     * @param anchor The scale origin (defaults to the center of the geometry extent).
+     */
+    public native void scale(double scaleX, double scaleY, Coordinate anchor);
+
 }

--- a/gwt-ol3-client/src/main/java/ol/geom/Polygon.java
+++ b/gwt-ol3-client/src/main/java/ol/geom/Polygon.java
@@ -17,6 +17,7 @@ package ol.geom;
 
 import jsinterop.annotations.JsType;
 import ol.Coordinate;
+import ol.Extent;
 
 /**
  * Polygon geometry.
@@ -133,5 +134,13 @@ public class Polygon extends SimpleGeometryMultiCoordinates {
      * @return linear rings.
      */
     public native LinearRing[] getLinearRings();
+    
+    /**
+     * Test if the geometry and the passed extent intersect.
+     * 
+     * @param extent Extent.
+     * @return true if the geometry and the extent intersect.
+     */
+    public native boolean intersectsExtent(Extent extent);
 
 }

--- a/gwt-ol3-client/src/main/java/ol/interaction/TranslateOptions.java
+++ b/gwt-ol3-client/src/main/java/ol/interaction/TranslateOptions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2014, 2019 gwt-ol3
+ * Copyright 2014, 2019 gwt-ol
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,17 +37,17 @@ public class TranslateOptions implements Options {
      */
     @JsProperty
     public native void setFeatures(Collection<Feature> features);
-	
-	/**
-	 * A list of layers from which features should be translated. Alternatively,
-	 * a filter function can be provided. The function will be called for each
-	 * layer in the map and should return true for layers that you want to be
-	 * translatable. If the option is absent, all visible layers will be
-	 * considered translatable.
-	 * 
-	 * @param layer
-	 */
-	@JsProperty
-	public native void setLayers(Layer[] layer);
+
+    /**
+     * A list of layers from which features should be translated. Alternatively,
+     * a filter function can be provided. The function will be called for each
+     * layer in the map and should return true for layers that you want to be
+     * translatable. If the option is absent, all visible layers will be
+     * considered translatable.
+     *
+     * @param layer
+     */
+    @JsProperty
+    public native void setLayers(Layer[] layer);
 
 }

--- a/gwt-ol3-client/src/main/java/ol/interaction/TranslateOptions.java
+++ b/gwt-ol3-client/src/main/java/ol/interaction/TranslateOptions.java
@@ -22,6 +22,7 @@ import jsinterop.annotations.JsType;
 import ol.Collection;
 import ol.Feature;
 import ol.Options;
+import ol.layer.Layer;
 
 /**
  * @author Tino Desjardins
@@ -36,5 +37,17 @@ public class TranslateOptions implements Options {
      */
     @JsProperty
     public native void setFeatures(Collection<Feature> features);
+	
+	/**
+	 * A list of layers from which features should be translated. Alternatively,
+	 * a filter function can be provided. The function will be called for each
+	 * layer in the map and should return true for layers that you want to be
+	 * translatable. If the option is absent, all visible layers will be
+	 * considered translatable.
+	 * 
+	 * @param layer
+	 */
+	@JsProperty
+	public native void setLayers(Layer[] layer);
 
 }

--- a/gwt-ol3-client/src/main/java/ol/source/Vector.java
+++ b/gwt-ol3-client/src/main/java/ol/source/Vector.java
@@ -22,6 +22,7 @@ import ol.Collection;
 import ol.Coordinate;
 import ol.Extent;
 import ol.Feature;
+import ol.GenericFunction;
 
 /**
  * Provides a source of features for vector layers. Vector features provided by
@@ -163,5 +164,17 @@ public class Vector extends Source {
         Feature getFeature();
 
     }
+
+	/**
+	 * Iterate through all features whose geometry intersects the provided
+	 * extent, calling the callback with each feature. If the callback returns a
+	 * "truthy" value, iteration will stop and the function will return the same
+	 * value. If you only want to test for bounding box intersection, call the
+	 * #forEachFeatureInExtent() method instead.
+	 * 
+	 * @param extent Extent.
+	 * @param callback Called with each feature whose geometry intersects the provided extent.
+	 */
+	public native void forEachFeatureIntersectingExtent(Extent extent, GenericFunction<Feature, ?> callback);
 
 }

--- a/gwt-ol3-client/src/main/java/ol/source/Vector.java
+++ b/gwt-ol3-client/src/main/java/ol/source/Vector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2014, 2018 gwt-ol3
+ * Copyright 2014, 2019 gwt-ol
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -165,16 +165,16 @@ public class Vector extends Source {
 
     }
 
-	/**
-	 * Iterate through all features whose geometry intersects the provided
-	 * extent, calling the callback with each feature. If the callback returns a
-	 * "truthy" value, iteration will stop and the function will return the same
-	 * value. If you only want to test for bounding box intersection, call the
-	 * #forEachFeatureInExtent() method instead.
-	 * 
-	 * @param extent Extent.
-	 * @param callback Called with each feature whose geometry intersects the provided extent.
-	 */
-	public native void forEachFeatureIntersectingExtent(Extent extent, GenericFunction<Feature, ?> callback);
+    /**
+     * Iterate through all features whose geometry intersects the provided
+     * extent, calling the callback with each feature. If the callback returns a
+     * "truthy" value, iteration will stop and the function will return the same
+     * value. If you only want to test for bounding box intersection, call the
+     * #forEachFeatureInExtent() method instead.
+     *
+     * @param extent Extent.
+     * @param callback Called with each feature whose geometry intersects the provided extent.
+     */
+    public native void forEachFeatureIntersectingExtent(Extent extent, GenericFunction<Feature, ?> callback);
 
 }


### PR DESCRIPTION
Added some methods from the openlayers API which are missing in gwt-ol:

Polygon.intersectsExtent
SimpleGeometry.scale
TranslateOptions.setLayers
Vector.forEachFeatureIntersectingExtent