### PR TITLE
Use ol.layer.Base instead of ol.layer.Layer as base layer class.

### DIFF
--- a/gwt-ol3-client/src/main/java/ol/FeatureAtPixelFunction.java
+++ b/gwt-ol3-client/src/main/java/ol/FeatureAtPixelFunction.java
@@ -16,7 +16,7 @@
 package ol;
 
 import jsinterop.annotations.JsFunction;
-import ol.layer.Layer;
+import ol.layer.Base;
 
 /**
  * Callback for {@link PluggableMap#forEachFeatureAtPixel(Pixel, FeatureAtPixelFunction, FeatureAtPixelOptions)}
@@ -27,6 +27,10 @@ import ol.layer.Layer;
 @JsFunction
 public interface FeatureAtPixelFunction {
 
-    boolean call(Feature feature, Layer layer);
+	/**
+	 * <p><b>Note:</b>Due to missing type info in latest supported OpenLayers version (5.3.0), <code>layerFilter</code> param can not accept {@link ol.layer.Layer},
+     * but it accepts {@link ol.layer.Base} instead. This is fixed in OpenLayers 6 so it will change in gwt-ol at some point, too.</p>
+     */
+    boolean call(Feature feature, Base layer);
 
 }

--- a/gwt-ol3-client/src/main/java/ol/FeatureAtPixelFunction.java
+++ b/gwt-ol3-client/src/main/java/ol/FeatureAtPixelFunction.java
@@ -27,8 +27,8 @@ import ol.layer.Base;
 @JsFunction
 public interface FeatureAtPixelFunction {
 
-	/**
-	 * <p><b>Note:</b>Due to missing type info in latest supported OpenLayers version (5.3.0), <code>layerFilter</code> param can not accept {@link ol.layer.Layer},
+    /**
+     * <p><b>Note:</b>Due to missing type info in latest supported OpenLayers version (5.3.0), <code>layerFilter</code> param can not accept {@link ol.layer.Layer},
      * but it accepts {@link ol.layer.Base} instead. This is fixed in OpenLayers 6 so it will change in gwt-ol at some point, too.</p>
      */
     boolean call(Feature feature, Base layer);

--- a/gwt-ol3-client/src/main/java/ol/FeatureAtPixelOptions.java
+++ b/gwt-ol3-client/src/main/java/ol/FeatureAtPixelOptions.java
@@ -18,7 +18,7 @@ package ol;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
-import ol.layer.Layer;
+import ol.layer.Base;
 
 /**
  * Options for customizing {@link PluggableMap#forEachFeatureAtPixel(Pixel, GenericFunction, FeatureAtPixelOptions)}
@@ -29,17 +29,20 @@ import ol.layer.Layer;
 public class FeatureAtPixelOptions implements Options {
 
     /**
-     * Defines layer filter function. The filter function will receive one argument, the <code>layer-candidate</code> and it should return a <code>boolean</code> value.
+     * <p>Defines layer filter function. The filter function will receive one argument, the <code>layer-candidate</code> and it should return a <code>boolean</code> value.
      * Only layers which are visible and for which this function returns <code>true</code> will be tested for features.
-     * By default, all visible layers will be tested.
+     * By default, all visible layers will be tested.<p>
+     * 
+     * <p><b>Note:</b>Due to missing type info in latest supported OpenLayers version (5.3.0), <code>layerFilter</code> param can not accept {@link ol.layer.Layer},
+     * but it accepts {@link ol.layer.Base} instead. This is fixed in OpenLayers 6 so it will change in gwt-ol at some point, too.</p>
      *
      * @param layerFilter Layer filer function
      */
     @JsProperty
-    public native void setLayerFilter(GenericFunction<Layer, Boolean> layerFilter);
+    public native void setLayerFilter(GenericFunction<Base, Boolean> layerFilter);
 
     @JsProperty
-    public native GenericFunction<Layer, Boolean> getLayerFilter();
+    public native GenericFunction<Base, Boolean> getLayerFilter();
 
     /**
      * Defines hit-detection tolerance in pixels. Pixels inside the radius around the given position will be checked for features.

--- a/gwt-ol3-client/src/main/java/ol/FeatureAtPixelOptions.java
+++ b/gwt-ol3-client/src/main/java/ol/FeatureAtPixelOptions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2014, 2018 gwt-ol3
+ * Copyright 2014, 2020 gwt-ol
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ public class FeatureAtPixelOptions implements Options {
      * <p>Defines layer filter function. The filter function will receive one argument, the <code>layer-candidate</code> and it should return a <code>boolean</code> value.
      * Only layers which are visible and for which this function returns <code>true</code> will be tested for features.
      * By default, all visible layers will be tested.<p>
-     * 
+     *
      * <p><b>Note:</b>Due to missing type info in latest supported OpenLayers version (5.3.0), <code>layerFilter</code> param can not accept {@link ol.layer.Layer},
      * but it accepts {@link ol.layer.Base} instead. This is fixed in OpenLayers 6 so it will change in gwt-ol at some point, too.</p>
      *

--- a/gwt-ol3-client/src/test/java/ol/MapTest.java
+++ b/gwt-ol3-client/src/test/java/ol/MapTest.java
@@ -15,7 +15,7 @@
  *******************************************************************************/
 package ol;
 
-import ol.layer.Layer;
+import ol.layer.Base;
 import ol.proj.Projection;
 import ol.proj.ProjectionOptions;
 
@@ -57,7 +57,7 @@ public class MapTest extends GwtOLBaseTestCase {
             map.forEachFeatureAtPixel(new Pixel(100, 100), new FeatureAtPixelFunction() {
 
                 @Override
-                public boolean call(Feature feature, Layer layer) {
+                public boolean call(Feature feature, Base layer) {
                     return false;
                 }
 

--- a/gwt-ol3-client/src/test/java/ol/MapTest.java
+++ b/gwt-ol3-client/src/test/java/ol/MapTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2014, 2017 gwt-ol3
+ * Copyright 2014, 2020 gwt-ol
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
OpenLayers misses type info in latest supported version (5.3.0),
so use this as workaround. Note that this bug is fixed in OpenLayers 6.x,
so this should be reverted as soon as gwt-ol supports OpenLayers 6.

See: #155