### PR TITLE
Remove dependencies to GWT HandlerRegistration

### DIFF
--- a/gwt-ol3-client/src/main/java/ol/Collection.java
+++ b/gwt-ol3-client/src/main/java/ol/Collection.java
@@ -15,14 +15,13 @@
  *******************************************************************************/
 package ol;
 
-import com.google.gwt.event.shared.HandlerRegistration;
-
 import javax.annotation.Nullable;
 
 import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
 import ol.event.EventListener;
+import ol.gwt.HandlerRegistration;
 
 /**
  *

--- a/gwt-ol3-client/src/main/java/ol/MapOptions.java
+++ b/gwt-ol3-client/src/main/java/ol/MapOptions.java
@@ -15,12 +15,10 @@
  *******************************************************************************/
 package ol;
 
-import com.google.gwt.dom.client.Document;
-import com.google.gwt.dom.client.Element;
-
+import elemental2.dom.Document;
+import elemental2.dom.Element;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
-
 import jsinterop.annotations.JsType;
 import ol.control.Control;
 import ol.interaction.Interaction;

--- a/gwt-ol3-client/src/main/java/ol/OLUtil.java
+++ b/gwt-ol3-client/src/main/java/ol/OLUtil.java
@@ -1,27 +1,26 @@
 /*******************************************************************************
  * Copyright 2014, 2020 gwt-ol
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  *******************************************************************************/
+
 package ol;
 
-import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.ui.Widget;
 
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 import elemental2.core.JsArray;
+import elemental2.dom.Element;
 import jsinterop.base.Js;
 import ol.event.EventListener;
 import ol.event.OLHandlerRegistration;
@@ -29,6 +28,7 @@ import ol.events.Event;
 import ol.geom.Polygon;
 import ol.geom.SimpleGeometryCoordinates;
 import ol.gwt.CollectionWrapper;
+import ol.gwt.HandlerRegistration;
 import ol.layer.Base;
 import ol.layer.Layer;
 import ol.proj.Projection;
@@ -49,81 +49,71 @@ import ol.tilegrid.XyzTileGridOptions;
 @ParametersAreNonnullByDefault
 public final class OLUtil {
 
-    /**
-     * Radius equal to the semi-major axis of the normal ellipsoid (like
-     * ol.sphere.NORMAL).
-     */
-    public static final double EARTH_RADIUS_NORMAL = 6370997;
+  /**
+   * Radius equal to the semi-major axis of the normal ellipsoid (like ol.sphere.NORMAL).
+   */
+  public static final double EARTH_RADIUS_NORMAL = 6370997;
 
-    /**
-     * Radius equal to the semi-major axis of the WGS84 ellipsoid (like
-     * ol.sphere.WGS84).
-     */
-    public static final double EARTH_RADIUS_WGS84 = 6378137;
+  /**
+   * Radius equal to the semi-major axis of the WGS84 ellipsoid (like ol.sphere.WGS84).
+   */
+  public static final double EARTH_RADIUS_WGS84  = 6378137;
 
-    // prevent instantiating this class
-    @Deprecated
-    private OLUtil() {
-        throw new AssertionError();
-    }
+  // prevent instantiating this class
+  @Deprecated
+  private OLUtil() {
+    throw new AssertionError();
+  }
 
-    /**
-     * Adds an item to the array.
-     *
-     * @param array array (will be changed)
-     * @param item item to add
-     * @return array including the item
-     */
-    @SuppressWarnings("unchecked")
-    public static <T> T[] pushItem(T[] array, T item) {
-        JsArray<T> jsArray = Js.cast(array);
-        jsArray.push(item);
-        return array;
-    }
+  /**
+   * Adds an item to the array.
+   *
+   * @param array array (will be changed)
+   * @param item item to add
+   * @return array including the item
+   */
+  @SuppressWarnings("unchecked")
+  public static <T> T[] pushItem(T[] array, T item) {
+    JsArray<T> jsArray = Js.cast(array);
+    jsArray.push(item);
+    return array;
+  }
 
-    /**
-     * Combines two arrays.
-     *
-     * @param array1 first array
-     * @param array2 second array
-     * @return combined array
-     */
-    public static <T> T[] concatArrays(T[] array1, T[] array2) {
-        JsArray<T> jsArray = JsArray.asJsArray(array1);
-        return jsArray.concat(array2).asArray(array1);
-    }
+  /**
+   * Combines two arrays.
+   *
+   * @param array1 first array
+   * @param array2 second array
+   * @return combined array
+   */
+  public static <T> T[] concatArrays(T[] array1, T[] array2) {
+    JsArray<T> jsArray = JsArray.asJsArray(array1);
+    return jsArray.concat(array2).asArray(array1);
+  }
 
-    /**
-     * Combines {@link Style}s into an array of {@link Style}s.
-     *
-     * @param s1
-     *            {@link Style} 1
-     * @param s2
-     *            {@link Style} 2
-     * @return array of {@link Style}s
-     */
-    public static Style[] combineStyles(Style... styles) {
-        return styles;
-    };
+  /**
+   * Combines {@link Style}s into an array of {@link Style}s.
+   *
+   * @param s1 {@link Style} 1
+   * @param s2 {@link Style} 2
+   * @return array of {@link Style}s
+   */
+  public static Style[] combineStyles(Style... styles) {
+    return styles;
+  };
 
 
-    /**
-     * Links to {@link Event}s by delegating the childs methods to the parents
-     * methods.
-     *
-     * @param eParent
-     *            parent {@link Event} (is not changed)
-     * @param type
-     *            type of the event
-     * @param currentTarget
-     *            current target of the child event
-     * @return child {@link Event} (gets its methods linked to the parent event)
-     * @param <T>
-     *            type of the event
-     * @param <U>
-     *            type of the target
-     */
-    public static native <T extends Event, U> T createLinkedEvent(T eParent, String type, U currentTarget) /*-{
+  /**
+   * Links to {@link Event}s by delegating the childs methods to the parents methods.
+   *
+   * @param eParent parent {@link Event} (is not changed)
+   * @param type type of the event
+   * @param currentTarget current target of the child event
+   * @return child {@link Event} (gets its methods linked to the parent event)
+   * @param <T> type of the event
+   * @param <U> type of the target
+   */
+  public static native <T extends Event, U> T createLinkedEvent(T eParent, String type, U currentTarget) /*-{
         var eChild = {};
         eChild.preventDefault = function() {
             eParent.preventDefault();
@@ -139,342 +129,306 @@ public final class OLUtil {
         return eChild;
     }-*/;
 
-    /**
-     * Creates a sphere options with radius equal to the semi-major axis of the WGS84
-     * ellipsoid.
-     * @return {@link SphereMetricOptions}
-     */
-    public static SphereMetricOptions createSphereOptionsWGS84() {
-        SphereMetricOptions sphereMetricOptions = new SphereMetricOptions();
-        sphereMetricOptions.setRadius(EARTH_RADIUS_WGS84);
-        return sphereMetricOptions;
-    }
+  /**
+   * Creates a sphere options with radius equal to the semi-major axis of the WGS84 ellipsoid.
+   * 
+   * @return {@link SphereMetricOptions}
+   */
+  public static SphereMetricOptions createSphereOptionsWGS84() {
+    SphereMetricOptions sphereMetricOptions = new SphereMetricOptions();
+    sphereMetricOptions.setRadius(EARTH_RADIUS_WGS84);
+    return sphereMetricOptions;
+  }
 
-    /**
-     * Creates a sphere options with radius equal to the semi-major axis of the normal
-     * ellipsoid.
-     * @return {@link SphereMetricOptions}
-     */
-    public static SphereMetricOptions createSphereOptionsNormal() {
-        SphereMetricOptions sphereMetricOptions = new SphereMetricOptions();
-        sphereMetricOptions.setRadius(EARTH_RADIUS_NORMAL);
-        return sphereMetricOptions;
-    }
+  /**
+   * Creates a sphere options with radius equal to the semi-major axis of the normal ellipsoid.
+   * 
+   * @return {@link SphereMetricOptions}
+   */
+  public static SphereMetricOptions createSphereOptionsNormal() {
+    SphereMetricOptions sphereMetricOptions = new SphereMetricOptions();
+    sphereMetricOptions.setRadius(EARTH_RADIUS_NORMAL);
+    return sphereMetricOptions;
+  }
 
-    /**
-     * Gets the geometry layout string for the given dimension.
-     *
-     * @param dim
-     *            dimension (i.e. 2 or 3)
-     * @return geometry layout string
-     */
-    public static String getGeometryLayout(int dim) {
-        if(dim > 2) {
-            return "XYZ";
-        }
-        return "XY";
+  /**
+   * Gets the geometry layout string for the given dimension.
+   *
+   * @param dim dimension (i.e. 2 or 3)
+   * @return geometry layout string
+   */
+  public static String getGeometryLayout(int dim) {
+    if (dim > 2) {
+      return "XYZ";
     }
+    return "XY";
+  }
 
-    /**
-     * Gets the geometry layout string for the given dimension.
-     *
-     * @param dim
-     *            dimension (i.e. 2 or 3)
-     * @param measure
-     *            include measure 'M' coordinate?
-     * @return geometry layout string
-     */
-    public static String getGeometryLayout(int dim, boolean measure) {
-        if(measure) {
-            if(dim > 2) {
-                return "XYZM";
-            }
-            return "XYM";
-        } else {
-            if(dim > 2) {
-                return "XYZ";
-            }
-            return "XY";
-        }
+  /**
+   * Gets the geometry layout string for the given dimension.
+   *
+   * @param dim dimension (i.e. 2 or 3)
+   * @param measure include measure 'M' coordinate?
+   * @return geometry layout string
+   */
+  public static String getGeometryLayout(int dim, boolean measure) {
+    if (measure) {
+      if (dim > 2) {
+        return "XYZM";
+      }
+      return "XYM";
+    } else {
+      if (dim > 2) {
+        return "XYZ";
+      }
+      return "XY";
     }
+  }
 
-    /**
-     * Determines the ground resolution (in meters per pixel) at a specified
-     * latitude and level of detail.
-     *
-     * @param latitude
-     *            latitude
-     * @param zoomLevel
-     *            zoomlevel
-     * @return ground resolution
-     */
-    public static double getGroundResolutionInMeters(double latitude, int zoomLevel) {
-        return Math.cos(latitude * Math.PI / 180) * 2 * Math.PI * EARTH_RADIUS_WGS84 / getMapSizeInPixels(zoomLevel);
+  /**
+   * Determines the ground resolution (in meters per pixel) at a specified latitude and level of
+   * detail.
+   *
+   * @param latitude latitude
+   * @param zoomLevel zoomlevel
+   * @return ground resolution
+   */
+  public static double getGroundResolutionInMeters(double latitude, int zoomLevel) {
+    return Math.cos(latitude * Math.PI / 180) * 2 * Math.PI * EARTH_RADIUS_WGS84 / getMapSizeInPixels(zoomLevel);
+  }
+
+  /**
+   * Gets a layer by the given name.
+   *
+   * @param map {@link PluggableMap}
+   * @param name name of the layer
+   * @return {@link Layer} on success, else null
+   */
+  @Nullable
+  public static Base getLayerByName(PluggableMap map, String name) {
+    CollectionWrapper<Base> layers = new CollectionWrapper<Base>(map.getLayers());
+    for (Base layer : layers) {
+      if (name.equals(getName(layer))) {
+        return layer;
+      }
     }
+    return null;
+  }
 
-    /**
-     * Gets a layer by the given name.
-     *
-     * @param map
-     *            {@link PluggableMap}
-     * @param name
-     *            name of the layer
-     * @return {@link Layer} on success, else null
-     */
-    @Nullable
-    public static Base getLayerByName(PluggableMap map, String name) {
-        CollectionWrapper<Base> layers = new CollectionWrapper<Base>(map.getLayers());
-        for(Base layer : layers) {
-            if(name.equals(getName(layer))) {
-                return layer;
-            }
-        }
-        return null;
-    }
+  /**
+   * Determines the map width and height (in pixels) at a specified level of detail.
+   *
+   * @param zoomLevel Level of detail, from 1 (lowest detail) to 23 (highest detail).
+   * @return The map width and height in pixels.
+   */
+  public static double getMapSizeInPixels(int zoomLevel) {
+    return ((double) (1 << zoomLevel)) * 256;
+  }
 
-    /**
-     * Determines the map width and height (in pixels) at a specified level of
-     * detail.
-     *
-     * @param zoomLevel
-     *            Level of detail, from 1 (lowest detail) to 23 (highest
-     *            detail).
-     * @return The map width and height in pixels.
-     */
-    public static double getMapSizeInPixels(int zoomLevel) {
-        return ((double)(1 << zoomLevel)) * 256;
-    }
+  /**
+   * Gets the name of the given {@link Layer}.
+   *
+   * @param layer {@link Layer}
+   * @return name on success, else null
+   */
+  @Nullable
+  public static String getName(Base layer) {
+    return layer.get("name");
+  }
 
-    /**
-     * Gets the name of the given {@link Layer}.
-     *
-     * @param layer
-     *            {@link Layer}
-     * @return name on success, else null
-     */
-    @Nullable
-    public static String getName(Base layer) {
-        return layer.get("name");
-    }
-
-    /**
-     * Gets a {@link TileGrid} from the given object, if the property is set
-     *
-     * @param source
-     *            {@link ol.source.Source}
-     * @return {@link TileGrid} on success, else null
-     */
-    private static native TileGrid getTileGrid(ol.source.Source source) /*-{
+  /**
+   * Gets a {@link TileGrid} from the given object, if the property is set
+   *
+   * @param source {@link ol.source.Source}
+   * @return {@link TileGrid} on success, else null
+   */
+  private static native TileGrid getTileGrid(ol.source.Source source) /*-{
         return source.tileGrid || null;
     }-*/;
 
-    /**
-     * Gets the current zoom level of the given {@link View}.
-     * @param view
-     *            {@link View}
-     * @return Zoom on success, else {@link Double#NaN}
-     */
-    private static native double getZoom(View view) /*-{
+  /**
+   * Gets the current zoom level of the given {@link View}.
+   * 
+   * @param view {@link View}
+   * @return Zoom on success, else {@link Double#NaN}
+   */
+  private static native double getZoom(View view) /*-{
     return view.getZoom() || NaN;
     }-*/;
 
-    /**
-     * Gets the current zoomlevel of the given {@link PluggableMap}.
-     * @param map
-     *            {@link PluggableMap}
-     * @return zoomlevel on success, else {@link Double#NaN}
-     */
-    public static double getZoomLevel(PluggableMap map) {
-        View v = map.getView();
-        // try to get zoom
-        double z = getZoom(v);
-        if(!Double.isNaN(z)) {
-            return z;
-        }
-        // zoom is undefined, so check resolution
-        double zoomResolution = v.getResolution();
-        // walk layers to find resolution
-        CollectionWrapper<Base> layers = new CollectionWrapper<Base>(map.getLayers());
-        for(Base l : layers) {
-            // get source if layer instance has it
-            Source source = l.get("source");
-            if(source != null) {
-                // try to get a tilegrid from the source
-                TileGrid tg = getTileGrid(source);
-                if(tg != null) {
-                    // check resolutions
-                    double[] resolutions = tg.getResolutions();
-                    if(resolutions != null) {
-                        double dPreviousResolution = 0;
-                        for(int i = 0; i < resolutions.length; i++) {
-                            // resolutions are sorted in descending order, so
-                            // compare with actual one
-                            double resolution = resolutions[i];
-                            if(resolution <= zoomResolution) {
-                                if(i > 1) {
-                                    // calculate the delta of the resolution
-                                    // compared to the current and the previous
-                                    // zoomlevel
-                                    double delta = (resolution - zoomResolution) / (dPreviousResolution - resolution);
-                                    // adjust the integer zoomlevel to the delta
-                                    return i + delta;
-                                } else {
-                                    return 0;
-                                }
-                            }
-                            dPreviousResolution = resolution;
-                        }
-                    }
+  /**
+   * Gets the current zoomlevel of the given {@link PluggableMap}.
+   * 
+   * @param map {@link PluggableMap}
+   * @return zoomlevel on success, else {@link Double#NaN}
+   */
+  public static double getZoomLevel(PluggableMap map) {
+    View v = map.getView();
+    // try to get zoom
+    double z = getZoom(v);
+    if (!Double.isNaN(z)) {
+      return z;
+    }
+    // zoom is undefined, so check resolution
+    double zoomResolution = v.getResolution();
+    // walk layers to find resolution
+    CollectionWrapper<Base> layers = new CollectionWrapper<Base>(map.getLayers());
+    for (Base l : layers) {
+      // get source if layer instance has it
+      Source source = l.get("source");
+      if (source != null) {
+        // try to get a tilegrid from the source
+        TileGrid tg = getTileGrid(source);
+        if (tg != null) {
+          // check resolutions
+          double[] resolutions = tg.getResolutions();
+          if (resolutions != null) {
+            double dPreviousResolution = 0;
+            for (int i = 0; i < resolutions.length; i++) {
+              // resolutions are sorted in descending order, so
+              // compare with actual one
+              double resolution = resolutions[i];
+              if (resolution <= zoomResolution) {
+                if (i > 1) {
+                  // calculate the delta of the resolution
+                  // compared to the current and the previous
+                  // zoomlevel
+                  double delta = (resolution - zoomResolution) / (dPreviousResolution - resolution);
+                  // adjust the integer zoomlevel to the delta
+                  return i + delta;
+                } else {
+                  return 0;
                 }
+              }
+              dPreviousResolution = resolution;
             }
+          }
         }
-        return Double.NaN;
+      }
     }
+    return Double.NaN;
+  }
 
-    /**
-     * Returns the geodesic area in square meters of the given geometry using
-     * the haversine formula.
-     *
-     * @param geom
-     *            geometry.
-     * @return geodesic area
-     */
-    public static double geodesicArea(Polygon geom) {
-        SphereMetricOptions sphereMetricOptions =  OLUtil.createSphereOptionsNormal();
-        sphereMetricOptions.setProjection(Projection.get("EPSG:4326"));
-        return Sphere.getArea(geom, sphereMetricOptions);
-    }
+  /**
+   * Returns the geodesic area in square meters of the given geometry using the haversine formula.
+   *
+   * @param geom geometry.
+   * @return geodesic area
+   */
+  public static double geodesicArea(Polygon geom) {
+    SphereMetricOptions sphereMetricOptions = OLUtil.createSphereOptionsNormal();
+    sphereMetricOptions.setProjection(Projection.get("EPSG:4326"));
+    return Sphere.getArea(geom, sphereMetricOptions);
+  }
 
-    /**
-     * Returns the geodesic length in meters of the given geometry using the
-     * haversine formula.
-     *
-     * @param geom
-     *            geometry.
-     * @return geodesic length on success, else {@link Double#NaN}
-     */
-    public static double geodesicLength(SimpleGeometryCoordinates geom) {
-        SphereMetricOptions sphereMetricOptions =  OLUtil.createSphereOptionsNormal();
-        sphereMetricOptions.setProjection(Projection.get("EPSG:4326"));
-        return Sphere.getLength(geom, sphereMetricOptions);
-    }
+  /**
+   * Returns the geodesic length in meters of the given geometry using the haversine formula.
+   *
+   * @param geom geometry.
+   * @return geodesic length on success, else {@link Double#NaN}
+   */
+  public static double geodesicLength(SimpleGeometryCoordinates geom) {
+    SphereMetricOptions sphereMetricOptions = OLUtil.createSphereOptionsNormal();
+    sphereMetricOptions.setProjection(Projection.get("EPSG:4326"));
+    return Sphere.getLength(geom, sphereMetricOptions);
+  }
 
-    /**
-     * Initializes a {@link MapEvent}, can be used for creating a new
-     * {@link MapEvent} as it does not work with ol.js in release mode using the
-     * OpenLayers API.
-     *
-     * @param e
-     *            base {@link Event}
-     * @param map
-     *            {@link PluggableMap}
-     * @return {@link MapEvent}
-     */
-    public static native MapEvent initMapEvent(Event e, PluggableMap map) /*-{
+  /**
+   * Initializes a {@link MapEvent}, can be used for creating a new {@link MapEvent} as it does not
+   * work with ol.js in release mode using the OpenLayers API.
+   *
+   * @param e base {@link Event}
+   * @param map {@link PluggableMap}
+   * @return {@link MapEvent}
+   */
+  public static native MapEvent initMapEvent(Event e, PluggableMap map) /*-{
         e.map = map;
         e.framestate = null;
         return e;
     }-*/;
 
-    /**
-     * Limits the zoomlevels of the {@link Xyz} layer source created of the
-     * given {@link XyzOptions}.
-     *
-     * @param options
-     *            {@link XyzOptions}
-     * @param minZoomLevel
-     *            minimum zoomlevel (0-28)
-     * @param maxZoomLevel
-     *            maximum zoomlevel (0-28)
-     */
-    public static void limitZoomLevels(XyzOptions options, int minZoomLevel, int maxZoomLevel) {
-        XyzTileGridOptions tileGridOptions = OLFactory.createOptions();
-        tileGridOptions.setMinZoom(minZoomLevel);
-        tileGridOptions.setMaxZoom(maxZoomLevel);
-        options.setTileGrid(OLFactory.createTileGridXYZ(tileGridOptions));
+  /**
+   * Limits the zoomlevels of the {@link Xyz} layer source created of the given {@link XyzOptions}.
+   *
+   * @param options {@link XyzOptions}
+   * @param minZoomLevel minimum zoomlevel (0-28)
+   * @param maxZoomLevel maximum zoomlevel (0-28)
+   */
+  public static void limitZoomLevels(XyzOptions options, int minZoomLevel, int maxZoomLevel) {
+    XyzTileGridOptions tileGridOptions = OLFactory.createOptions();
+    tileGridOptions.setMinZoom(minZoomLevel);
+    tileGridOptions.setMaxZoom(maxZoomLevel);
+    options.setTileGrid(OLFactory.createTileGridXYZ(tileGridOptions));
+  }
+
+  /**
+   * Registers the given event listener to listen for the given event type on the given
+   * {@link Observable}.
+   *
+   * @param o {@link Observable}
+   * @param eventType event type
+   * @param listener listener
+   * @return {@link HandlerRegistration}
+   */
+  public static <E extends Event> HandlerRegistration observe(Observable o, String eventType,
+      EventListener<E> listener) {
+    EventsKey key = o.on(eventType, listener);
+    return new OLHandlerRegistration(o, key);
+  }
+
+  /**
+   * Registers the given event listener to listen once for the given event type on the given
+   * {@link Observable}.
+   *
+   * @param o {@link Observable}
+   * @param eventType event type
+   * @param listener listener
+   * @return {@link HandlerRegistration}
+   */
+  public static <E extends Event> HandlerRegistration observeOnce(Observable o, String eventType,
+      EventListener<E> listener) {
+    EventsKey key = o.once(eventType, listener);
+    return new OLHandlerRegistration(o, key);
+  }
+
+  /**
+   * Sets the container for the given {@link PluggableMap} to the given {@link Widget}.
+   *
+   * @param map {@link PluggableMap}
+   * @param target {@link Widget}
+   */
+  public static void setMapTarget(PluggableMap map, Widget target) {
+    map.setTarget(Js.<Element>cast(target.getElement()));
+  }
+
+  /**
+   * Sets the name of the given {@link Layer}.
+   *
+   * @param layer {@link Layer}
+   * @param name name
+   */
+  public static void setName(Base layer, String name) {
+    layer.set("name", name);
+  }
+
+  /**
+   * Transforms coordinates from source projection to destination projection. This returns new
+   * coordinates (and does not modify the original).
+   *
+   * @param coordinates coordinates to transform
+   * @param source source projection
+   * @param destination destination projection
+   * @return transformed coordinates
+   */
+  public static Coordinate[] transform(Coordinate[] coordinates, String source, String destination) {
+
+    Coordinate[] transformedCoordinates = new Coordinate[coordinates.length];
+
+    for (int i = 0; i < coordinates.length; i++) {
+      transformedCoordinates[i] = Projection.transform(coordinates[i], source, destination);
     }
 
-    /**
-     * Registers the given event listener to listen for the given event type on
-     * the given {@link Observable}.
-     *
-     * @param o
-     *            {@link Observable}
-     * @param eventType
-     *            event type
-     * @param listener
-     *            listener
-     * @return {@link HandlerRegistration}
-     */
-    public static <E extends Event> HandlerRegistration observe(Observable o, String eventType,
-            EventListener<E> listener) {
-        EventsKey key = o.on(eventType, listener);
-        return new OLHandlerRegistration(o, key);
-    }
-
-    /**
-     * Registers the given event listener to listen once for the given event
-     * type on the given {@link Observable}.
-     *
-     * @param o
-     *            {@link Observable}
-     * @param eventType
-     *            event type
-     * @param listener
-     *            listener
-     * @return {@link HandlerRegistration}
-     */
-    public static <E extends Event> HandlerRegistration observeOnce(Observable o, String eventType,
-            EventListener<E> listener) {
-        EventsKey key = o.once(eventType, listener);
-        return new OLHandlerRegistration(o, key);
-    }
-
-    /**
-     * Sets the container for the given {@link PluggableMap} to the given {@link Widget}.
-     *
-     * @param map
-     *            {@link PluggableMap}
-     * @param target
-     *            {@link Widget}
-     */
-    public static void setMapTarget(PluggableMap map, Widget target) {
-        map.setTarget(target.getElement());
-    }
-
-    /**
-     * Sets the name of the given {@link Layer}.
-     *
-     * @param layer
-     *            {@link Layer}
-     * @param name
-     *            name
-     */
-    public static void setName(Base layer, String name) {
-        layer.set("name", name);
-    }
-
-    /**
-     * Transforms coordinates from source projection to destination projection.
-     * This returns new coordinates (and does not modify the original).
-     *
-     * @param coordinates
-     *            coordinates to transform
-     * @param source
-     *            source projection
-     * @param destination
-     *            destination projection
-     * @return transformed coordinates
-     */
-    public static Coordinate[] transform(Coordinate[] coordinates, String source, String destination) {
-
-        Coordinate[] transformedCoordinates = new Coordinate[coordinates.length];
-
-        for(int i = 0; i < coordinates.length; i++) {
-            transformedCoordinates[i] = Projection.transform(coordinates[i], source, destination);
-        }
-
-        return transformedCoordinates;
-    }
+    return transformedCoordinates;
+  }
 
 }

--- a/gwt-ol3-client/src/main/java/ol/Observable.java
+++ b/gwt-ol3-client/src/main/java/ol/Observable.java
@@ -15,13 +15,12 @@
  *******************************************************************************/
 package ol;
 
-import com.google.gwt.event.shared.HandlerRegistration;
-
 import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsType;
 import ol.event.EventListener;
 import ol.events.Event;
 import ol.events.EventTarget;
+import ol.gwt.HandlerRegistration;
 
 /**
  * Abstract base class; normally only used for creating subclasses and not

--- a/gwt-ol3-client/src/main/java/ol/Overlay.java
+++ b/gwt-ol3-client/src/main/java/ol/Overlay.java
@@ -15,8 +15,7 @@
  *******************************************************************************/
 package ol;
 
-import com.google.gwt.dom.client.Element;
-
+import elemental2.dom.Element;
 import jsinterop.annotations.JsType;
 
 /**

--- a/gwt-ol3-client/src/main/java/ol/OverlayOptions.java
+++ b/gwt-ol3-client/src/main/java/ol/OverlayOptions.java
@@ -15,8 +15,7 @@
  *******************************************************************************/
 package ol;
 
-import com.google.gwt.dom.client.Element;
-
+import elemental2.dom.Element;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;

--- a/gwt-ol3-client/src/main/java/ol/PluggableMap.java
+++ b/gwt-ol3-client/src/main/java/ol/PluggableMap.java
@@ -15,14 +15,13 @@
  *******************************************************************************/
 package ol;
 
-import com.google.gwt.dom.client.Element;
-import com.google.gwt.event.shared.HandlerRegistration;
-
+import elemental2.dom.Element;
 import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
 import ol.control.Control;
 import ol.event.EventListener;
+import ol.gwt.HandlerRegistration;
 import ol.interaction.Interaction;
 import ol.layer.Base;
 import ol.layer.Group;

--- a/gwt-ol3-client/src/main/java/ol/View.java
+++ b/gwt-ol3-client/src/main/java/ol/View.java
@@ -15,14 +15,13 @@
  *******************************************************************************/
 package ol;
 
-import com.google.gwt.event.shared.HandlerRegistration;
-
 import javax.annotation.Nullable;
 
 import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsType;
 import ol.animation.AnimationOptions;
 import ol.event.EventListener;
+import ol.gwt.HandlerRegistration;
 import ol.proj.Projection;
 
 /**

--- a/gwt-ol3-client/src/main/java/ol/control/Control.java
+++ b/gwt-ol3-client/src/main/java/ol/control/Control.java
@@ -15,12 +15,10 @@
  *******************************************************************************/
 package ol.control;
 
-import com.google.gwt.dom.client.Element;
-
+import elemental2.dom.Element;
 import jsinterop.annotations.JsMethod;
 import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsProperty;
-
 import jsinterop.annotations.JsType;
 import ol.Collection;
 import ol.Object;

--- a/gwt-ol3-client/src/main/java/ol/control/ControlOptions.java
+++ b/gwt-ol3-client/src/main/java/ol/control/ControlOptions.java
@@ -15,8 +15,7 @@
  *******************************************************************************/
 package ol.control;
 
-import com.google.gwt.dom.client.Element;
-
+import elemental2.dom.Element;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;

--- a/gwt-ol3-client/src/main/java/ol/event/OLHandlerRegistration.java
+++ b/gwt-ol3-client/src/main/java/ol/event/OLHandlerRegistration.java
@@ -15,10 +15,9 @@
  *******************************************************************************/
 package ol.event;
 
-import com.google.gwt.event.shared.HandlerRegistration;
-
 import ol.EventsKey;
 import ol.Observable;
+import ol.gwt.HandlerRegistration;
 
 /**
  * A {@link HandlerRegistration} for OpenLayers event handlers.

--- a/gwt-ol3-client/src/main/java/ol/gwt/HandlerRegistration.java
+++ b/gwt-ol3-client/src/main/java/ol/gwt/HandlerRegistration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2014, 2018 gwt-ol3
+ * Copyright 2014, 2015 gwt-ol3
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,18 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *******************************************************************************/
-package ol;
-
-import elemental2.dom.HTMLImageElement;
-import jsinterop.annotations.JsType;
+package ol.gwt;
 
 /**
- *
- * ImageTile.
- *
+ * Registration objects returned when an event handler is bound, used to de-register.
  */
-@JsType(isNative = true)
-public class ImageTile extends Tile {
+@FunctionalInterface
+public interface HandlerRegistration {
 
-    public native HTMLImageElement getImage();
+  /**
+   * De-registers the handler associated with this registration object if the handler is still
+   * attached to the event source. If the handler is no longer attached to the event source, this is
+   * a no-op.
+   */
+  void removeHandler();
 }

--- a/gwt-ol3-client/src/main/java/ol/gwt/Measure.java
+++ b/gwt-ol3-client/src/main/java/ol/gwt/Measure.java
@@ -15,8 +15,6 @@
  *******************************************************************************/
 package ol.gwt;
 
-import com.google.gwt.event.shared.HandlerRegistration;
-
 import jsinterop.annotations.JsIgnore;
 import jsinterop.annotations.JsType;
 import ol.Feature;

--- a/gwt-ol3-client/src/main/java/ol/interaction/DragBox.java
+++ b/gwt-ol3-client/src/main/java/ol/interaction/DragBox.java
@@ -15,8 +15,6 @@
  *******************************************************************************/
 package ol.interaction;
 
-import com.google.gwt.event.shared.HandlerRegistration;
-
 import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
@@ -25,6 +23,7 @@ import ol.MapBrowserEvent;
 import ol.OLUtil;
 import ol.event.EventListener;
 import ol.geom.Polygon;
+import ol.gwt.HandlerRegistration;
 
 /**
  *

--- a/gwt-ol3-client/src/main/java/ol/interaction/Extent.java
+++ b/gwt-ol3-client/src/main/java/ol/interaction/Extent.java
@@ -15,13 +15,12 @@
  *******************************************************************************/
 package ol.interaction;
 
-import com.google.gwt.event.shared.HandlerRegistration;
-
 import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
 import ol.OLUtil;
 import ol.event.EventListener;
+import ol.gwt.HandlerRegistration;
 
 /**
  * Allows the user to draw a vector box by clicking and dragging on the map,

--- a/gwt-ol3-client/src/main/java/ol/interaction/Select.java
+++ b/gwt-ol3-client/src/main/java/ol/interaction/Select.java
@@ -17,8 +17,6 @@ package ol.interaction;
 
 import javax.annotation.Nullable;
 
-import com.google.gwt.event.shared.HandlerRegistration;
-
 import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
@@ -27,6 +25,7 @@ import ol.Feature;
 import ol.MapBrowserEvent;
 import ol.OLUtil;
 import ol.event.EventListener;
+import ol.gwt.HandlerRegistration;
 
 /**
  * Interaction for selecting vector features. By default, selected features are

--- a/gwt-ol3-client/src/main/java/ol/interaction/Translate.java
+++ b/gwt-ol3-client/src/main/java/ol/interaction/Translate.java
@@ -15,8 +15,6 @@
  *******************************************************************************/
 package ol.interaction;
 
-import com.google.gwt.event.shared.HandlerRegistration;
-
 import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
@@ -25,6 +23,7 @@ import ol.Coordinate;
 import ol.Feature;
 import ol.OLUtil;
 import ol.event.EventListener;
+import ol.gwt.HandlerRegistration;
 
 /**
  *

--- a/gwt-ol3-client/src/main/java/ol/source/Raster.java
+++ b/gwt-ol3-client/src/main/java/ol/source/Raster.java
@@ -17,8 +17,6 @@ package ol.source;
 
 import javax.annotation.Nullable;
 
-import com.google.gwt.event.shared.HandlerRegistration;
-
 import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
@@ -26,6 +24,7 @@ import jsinterop.base.JsPropertyMap;
 import ol.Extent;
 import ol.OLUtil;
 import ol.event.EventListener;
+import ol.gwt.HandlerRegistration;
 
 /**
  * @author Daniel Eggert (daniel.eggert@gfz-potsdam.de)

--- a/gwt-ol3-client/src/main/java/ol/source/Tile.java
+++ b/gwt-ol3-client/src/main/java/ol/source/Tile.java
@@ -15,13 +15,12 @@
  *******************************************************************************/
 package ol.source;
 
-import com.google.gwt.event.shared.HandlerRegistration;
-
 import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
 import ol.OLUtil;
 import ol.event.EventListener;
+import ol.gwt.HandlerRegistration;
 import ol.tilegrid.TileGrid;
 
 /**

--- a/gwt-ol3-demo/src/main/java/com/github/tdesjardins/ol3/demo/client/example/OverlayExample.java
+++ b/gwt-ol3-demo/src/main/java/com/github/tdesjardins/ol3/demo/client/example/OverlayExample.java
@@ -1,20 +1,26 @@
 /*******************************************************************************
  * Copyright 2014, 2018 gwt-ol3
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  *******************************************************************************/
+
 package com.github.tdesjardins.ol3.demo.client.example;
 
+import com.github.tdesjardins.ol3.demo.client.constants.DemoConstants;
+import com.github.tdesjardins.ol3.demo.client.utils.DemoUtils;
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.dom.client.DivElement;
+import com.google.gwt.dom.client.Document;
+
+import jsinterop.base.Js;
 import ol.Coordinate;
 import ol.Map;
 import ol.MapOptions;
@@ -23,18 +29,11 @@ import ol.Overlay;
 import ol.OverlayOptions;
 import ol.View;
 import ol.control.Attribution;
-
-import com.github.tdesjardins.ol3.demo.client.constants.DemoConstants;
-import com.github.tdesjardins.ol3.demo.client.utils.DemoUtils;
-import com.google.gwt.core.client.GWT;
-import com.google.gwt.dom.client.DivElement;
-import com.google.gwt.dom.client.Document;
-
+import ol.layer.LayerOptions;
 import ol.layer.Tile;
 import ol.proj.Projection;
 import ol.source.Osm;
 import ol.source.XyzOptions;
-import ol.layer.LayerOptions;
 
 /**
  * Example with OSM layer and tile debug layer.
@@ -44,64 +43,67 @@ import ol.layer.LayerOptions;
  */
 public class OverlayExample implements Example {
 
-    /* (non-Javadoc)
-     * @see de.desjardins.ol3.demo.client.example.Example#show()
-     */
-    @Override
-    public void show(String exampleId) {
+  /*
+   * (non-Javadoc)
+   * 
+   * @see de.desjardins.ol3.demo.client.example.Example#show()
+   */
+  @Override
+  public void show(String exampleId) {
 
-        // create a OSM-layer
-        XyzOptions osmSourceOptions = OLFactory.createOptions();
+    // create a OSM-layer
+    XyzOptions osmSourceOptions = OLFactory.createOptions();
 
-        Osm osmSource = new Osm(osmSourceOptions);
-        LayerOptions osmLayerOptions = OLFactory.createOptions();
-        osmLayerOptions.setSource(osmSource);
+    Osm osmSource = new Osm(osmSourceOptions);
+    LayerOptions osmLayerOptions = OLFactory.createOptions();
+    osmLayerOptions.setSource(osmSource);
 
-        Tile osmLayer = new Tile(osmLayerOptions);
+    Tile osmLayer = new Tile(osmLayerOptions);
 
-        // create a view
-        View view = new View();
+    // create a view
+    View view = new View();
 
-        Coordinate centerCoordinate = OLFactory.createCoordinate(2.3, 51.507222);
-        Coordinate transformedCenterCoordinate = Projection.transform(centerCoordinate, DemoConstants.EPSG_4326, DemoConstants.EPSG_3857);
+    Coordinate centerCoordinate = OLFactory.createCoordinate(2.3, 51.507222);
+    Coordinate transformedCenterCoordinate =
+        Projection.transform(centerCoordinate, DemoConstants.EPSG_4326, DemoConstants.EPSG_3857);
 
-        view.setCenter(transformedCenterCoordinate);
-        view.setZoom(10);
+    view.setCenter(transformedCenterCoordinate);
+    view.setZoom(10);
 
-        // create the map
-        MapOptions mapOptions = OLFactory.createOptions();
-        mapOptions.setTarget(exampleId);
-        mapOptions.setView(view);
+    // create the map
+    MapOptions mapOptions = OLFactory.createOptions();
+    mapOptions.setTarget(exampleId);
+    mapOptions.setView(view);
 
-        Map map = new Map(mapOptions);
+    Map map = new Map(mapOptions);
 
-        map.addLayer(osmLayer);
+    map.addLayer(osmLayer);
 
-        // add some controls
-        map.addControl(OLFactory.createScaleLine());
-        DemoUtils.addDefaultControls(map.getControls());
+    // add some controls
+    map.addControl(OLFactory.createScaleLine());
+    DemoUtils.addDefaultControls(map.getControls());
 
-        Attribution attribution = new Attribution();
-        attribution.setCollapsed(true);
+    Attribution attribution = new Attribution();
+    attribution.setCollapsed(true);
 
-        map.addControl(attribution);
+    map.addControl(attribution);
 
-        // add some interactions
-        map.addInteraction(OLFactory.createKeyboardPan());
-        map.addInteraction(OLFactory.createKeyboardZoom());
+    // add some interactions
+    map.addInteraction(OLFactory.createKeyboardPan());
+    map.addInteraction(OLFactory.createKeyboardZoom());
 
-        DivElement overlay = Document.get().createDivElement();
-        overlay.setClassName("overlay-font");
-        overlay.setInnerText("Created with GWT SDK " + GWT.getVersion());
+    DivElement overlay = Document.get().createDivElement();
+    overlay.setClassName("overlay-font");
+    overlay.setInnerText("Created with GWT SDK " + GWT.getVersion());
 
-        OverlayOptions overlayOptions = OLFactory.createOptions();
-        overlayOptions.setElement(overlay);
-        overlayOptions.setPosition(transformedCenterCoordinate);
-        overlayOptions.setOffset(OLFactory.createPixel(-300, 0));
+    OverlayOptions overlayOptions = OLFactory.createOptions();
+    overlayOptions.setElement(Js.cast(overlay));
+    overlayOptions.setPosition(transformedCenterCoordinate);
+    overlayOptions.setOffset(OLFactory.createPixel(-300, 0));
 
-        map.addOverlay(new Overlay(overlayOptions));
+    map.addOverlay(new Overlay(overlayOptions));
 
-    }
+  }
 
 }
 

--- a/gwt-ol3-demo/src/main/java/com/github/tdesjardins/ol3/demo/client/utils/DemoUtils.java
+++ b/gwt-ol3-demo/src/main/java/com/github/tdesjardins/ol3/demo/client/utils/DemoUtils.java
@@ -1,18 +1,17 @@
 /*******************************************************************************
  * Copyright 2014, 2018 gwt-ol3
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  *******************************************************************************/
+
 package com.github.tdesjardins.ol3.demo.client.utils;
 
 import com.github.tdesjardins.ol3.demo.client.constants.DemoConstants;
@@ -23,6 +22,7 @@ import com.google.gwt.dom.client.Style.Overflow;
 import com.google.gwt.dom.client.Style.Position;
 import com.google.gwt.dom.client.Style.Unit;
 
+import jsinterop.base.Js;
 import ol.Collection;
 import ol.Coordinate;
 import ol.OLFactory;
@@ -47,88 +47,89 @@ import ol.source.XyzOptions;
  */
 public final class DemoUtils {
 
-    private DemoUtils() {
-        throw new AssertionError();
-    }
+  private DemoUtils() {
+    throw new AssertionError();
+  }
 
-    /**
-     * Creates some default controls and adds it to the collection.
-     *
-     * @param controls collection with controls
-     */
-    public static void addDefaultControls(final Collection<Control> controls) {
+  /**
+   * Creates some default controls and adds it to the collection.
+   *
+   * @param controls collection with controls
+   */
+  public static void addDefaultControls(final Collection<Control> controls) {
 
-        controls.push(new FullScreen());
-        controls.push(new ZoomSlider());
-        MousePosition mousePosition = new MousePosition();
-        mousePosition.setCoordinateFormat(Coordinate.createStringXY(5));
-        controls.push(mousePosition);
-        controls.push(new ZoomToExtent());
+    controls.push(new FullScreen());
+    controls.push(new ZoomSlider());
+    MousePosition mousePosition = new MousePosition();
+    mousePosition.setCoordinateFormat(Coordinate.createStringXY(5));
+    controls.push(mousePosition);
+    controls.push(new ZoomToExtent());
 
-    }
+  }
 
-    /**
-     * Create a MapBox logo.
-     *
-     * @return MapBox logo
-     */
-    public static Control createMapboxLogo() {
+  /**
+   * Create a MapBox logo.
+   *
+   * @return MapBox logo
+   */
+  public static Control createMapboxLogo() {
 
-        ControlOptions controlOptions = new ControlOptions();
+    ControlOptions controlOptions = new ControlOptions();
 
-        LinkElement mapboxLogo = Document.get().createLinkElement();
-        mapboxLogo.setHref("https://mapbox.com/about/maps");
-        mapboxLogo.setTarget("_blank");
+    LinkElement mapboxLogo = Document.get().createLinkElement();
+    mapboxLogo.setHref("https://mapbox.com/about/maps");
+    mapboxLogo.setTarget("_blank");
 
-        mapboxLogo.getStyle().setPosition(Position.ABSOLUTE);
-        mapboxLogo.getStyle().setLeft(2, Unit.PX);
-        mapboxLogo.getStyle().setBottom(5, Unit.PX);
-        mapboxLogo.getStyle().setWidth(126, Unit.PX);
-        mapboxLogo.getStyle().setHeight(40, Unit.PX);
-        mapboxLogo.getStyle().setDisplay(Display.BLOCK);
-        mapboxLogo.getStyle().setOverflow(Overflow.HIDDEN);
+    mapboxLogo.getStyle().setPosition(Position.ABSOLUTE);
+    mapboxLogo.getStyle().setLeft(2, Unit.PX);
+    mapboxLogo.getStyle().setBottom(5, Unit.PX);
+    mapboxLogo.getStyle().setWidth(126, Unit.PX);
+    mapboxLogo.getStyle().setHeight(40, Unit.PX);
+    mapboxLogo.getStyle().setDisplay(Display.BLOCK);
+    mapboxLogo.getStyle().setOverflow(Overflow.HIDDEN);
 
-        mapboxLogo.getStyle().setBackgroundImage("url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIIAAAAoCAMAAAAFWtJHAAAAwFBMVEUAAAAAAAAAAABtbW0AAAAAAAAAAAAAAAAAAAAAAAClpaUAAADp6ekAAAD5+fna2toAAAAMDAzv7+/Nzc0AAAA2Njb8/Pz9/f3T09MAAAAAAAD7+/sAAAArKyuxsbH39/fs7OwbGxuIiIjz8/N8fHyenp7u7u74+PgAAAC8vLxWVlbx8fF1dXXl5eVcXFyUlJTQ0NDFxcVCQkLAwMC4uLj19fXo6OjW1tarq6ve3t77+/vi4uL6+vrKysrNzc3///8w7gSSAAAAP3RSTlMAOQNdPSYBPywKexLLGPCxNEHXnzFL+v2nGwf1IEiE6dBFad9jd9PuLo1V2mDDV3Cjl06SiuXIq4C3973ym6BQMVUPAAAEXElEQVR4Ae2WCVP6OBiH05L0l1IqrVbkKHJ54I0oHn+PfP9vtUle0z/YdhbH2XVnd58ZnRJIeHiPJOx//mH4vQSAN+8FjAhFxgHIaPvJeZ99hxwEElon5iAQbj85Y98g8ODwjEOMAvGFyeE3FEKgodTBqj0BJGN9DhyNd5Ta3ean9QEopfaA+LsKhnEKRExqg4FSP6Og7oEkAjBWnxSCgBX4xF+kcLoPcOBQrSv0e5kH7s1j37jECQieCTPiFGxL5VHw2zQWCeeJiPt6kjRQw0XSkIdVChf67xGa4alSnZlT6HEQ8CK9ANbhvXUF9xlDkBfTuHDWScgC9+z5FQpPI12TlwC6+sV7ixR8CUMKiwjm2GQeOQWHMGuHGdbnObJAwCEqFJpNU5H6uaPUaEIKiQfg+PHk1+u4OwW9PlWW2ctbA4BHCtp+cNK+H8Jos4gDmC5ar4Nx9waaG/2B13NgDqS7+vm2RgEtEws82P+kwIHhs/pgkQKcFIhfd7CogtGNjYMHTLpurD0ERbYFw4JaD3GlQuNAL/JEsSAF4HqlCnaHACk4WhOn4OgCkMD5hSpYNYDJTD8Y46n+jsE1kPhVCuR6QBXhFK7MUOu9O6b1SWF3b+/9ZVWMGOlu93E8UDaAhgc7bfH+0DHqKXCkHzoNDFfU+zxiVQrUC9QXTuHYtKpN59OA3IxCG4b7jh6ZFuVockaNTW09mkJzOaPU49a6mE9cAchZpQJNpUWcwgV9r6FJswsFKrITp2B5pMBMdnS0z2HZNy2+BNKxSZxZfglkrFYBJxQnpzA5sN/HheR2aFQoZBLAi149dQoyAYYjW0hHlHguBAdMcR0DuDZ5omevX6+AI8qcU7ikKT3GBHCnXwydgmCC0tRwCnGQ2Wp6Be71yNIWfQSkOl9vAI1SBCNWrwC01RROgX7BuT2HI4r7tFAw086p/NwZEdOEa7R1uAFuNmQPuKAEAjYNQ0CyeoUEWHYBnpQVQgpvc0Ph+gsKlAnKg1+vEHsw5LKciLKCAJobiWBzYFGbCKpHqkZZrxBFHEASyFI59vJPCskcwNVGOWZAOqsrR+pKbaNeAMT1CixMEtlnsqopNxUMzVJT3tY35aXZm6a6Y9QhwMN6BUJWbE1lhbMO1WehkO7poO0sK7em9MJGxp1XSbC1gtugzzSLQmGsX7VntJGSwsPZ2d2z3bIPKzdoOp3Wzqt8G4XyMVUoFIxLx1S7+piaHtCvR3FeRVsq0GFdp9C5TbGpcNqsPqyHKxcfd14h21KhuLKUFU4f3osrC7F6uV3WXFnadL7wyAPeKDXw2RoJCO5GY4DouYvb/gepVXheLoewzPseQG9N/vzilrMIjoStE3++zvle4eSurw7XEe76ynI4aq+v7lEyt1x5awiFlFLQbHKIpabnM3eJLym4Szzzc/du7SU+zOXv9UNpECH7IoH/gecURPlN9vdQpeD47yhIFNX0U0QgvID9nENm+yxk/xb+AGAjNfRZuk9qAAAAAElFTkSuQmCC)");
+    mapboxLogo.getStyle().setBackgroundImage(
+        "url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIIAAAAoCAMAAAAFWtJHAAAAwFBMVEUAAAAAAAAAAABtbW0AAAAAAAAAAAAAAAAAAAAAAAClpaUAAADp6ekAAAD5+fna2toAAAAMDAzv7+/Nzc0AAAA2Njb8/Pz9/f3T09MAAAAAAAD7+/sAAAArKyuxsbH39/fs7OwbGxuIiIjz8/N8fHyenp7u7u74+PgAAAC8vLxWVlbx8fF1dXXl5eVcXFyUlJTQ0NDFxcVCQkLAwMC4uLj19fXo6OjW1tarq6ve3t77+/vi4uL6+vrKysrNzc3///8w7gSSAAAAP3RSTlMAOQNdPSYBPywKexLLGPCxNEHXnzFL+v2nGwf1IEiE6dBFad9jd9PuLo1V2mDDV3Cjl06SiuXIq4C3973ym6BQMVUPAAAEXElEQVR4Ae2WCVP6OBiH05L0l1IqrVbkKHJ54I0oHn+PfP9vtUle0z/YdhbH2XVnd58ZnRJIeHiPJOx//mH4vQSAN+8FjAhFxgHIaPvJeZ99hxwEElon5iAQbj85Y98g8ODwjEOMAvGFyeE3FEKgodTBqj0BJGN9DhyNd5Ta3ean9QEopfaA+LsKhnEKRExqg4FSP6Og7oEkAjBWnxSCgBX4xF+kcLoPcOBQrSv0e5kH7s1j37jECQieCTPiFGxL5VHw2zQWCeeJiPt6kjRQw0XSkIdVChf67xGa4alSnZlT6HEQ8CK9ANbhvXUF9xlDkBfTuHDWScgC9+z5FQpPI12TlwC6+sV7ixR8CUMKiwjm2GQeOQWHMGuHGdbnObJAwCEqFJpNU5H6uaPUaEIKiQfg+PHk1+u4OwW9PlWW2ctbA4BHCtp+cNK+H8Jos4gDmC5ar4Nx9waaG/2B13NgDqS7+vm2RgEtEws82P+kwIHhs/pgkQKcFIhfd7CogtGNjYMHTLpurD0ERbYFw4JaD3GlQuNAL/JEsSAF4HqlCnaHACk4WhOn4OgCkMD5hSpYNYDJTD8Y46n+jsE1kPhVCuR6QBXhFK7MUOu9O6b1SWF3b+/9ZVWMGOlu93E8UDaAhgc7bfH+0DHqKXCkHzoNDFfU+zxiVQrUC9QXTuHYtKpN59OA3IxCG4b7jh6ZFuVockaNTW09mkJzOaPU49a6mE9cAchZpQJNpUWcwgV9r6FJswsFKrITp2B5pMBMdnS0z2HZNy2+BNKxSZxZfglkrFYBJxQnpzA5sN/HheR2aFQoZBLAi149dQoyAYYjW0hHlHguBAdMcR0DuDZ5omevX6+AI8qcU7ikKT3GBHCnXwydgmCC0tRwCnGQ2Wp6Be71yNIWfQSkOl9vAI1SBCNWrwC01RROgX7BuT2HI4r7tFAw086p/NwZEdOEa7R1uAFuNmQPuKAEAjYNQ0CyeoUEWHYBnpQVQgpvc0Ph+gsKlAnKg1+vEHsw5LKciLKCAJobiWBzYFGbCKpHqkZZrxBFHEASyFI59vJPCskcwNVGOWZAOqsrR+pKbaNeAMT1CixMEtlnsqopNxUMzVJT3tY35aXZm6a6Y9QhwMN6BUJWbE1lhbMO1WehkO7poO0sK7em9MJGxp1XSbC1gtugzzSLQmGsX7VntJGSwsPZ2d2z3bIPKzdoOp3Wzqt8G4XyMVUoFIxLx1S7+piaHtCvR3FeRVsq0GFdp9C5TbGpcNqsPqyHKxcfd14h21KhuLKUFU4f3osrC7F6uV3WXFnadL7wyAPeKDXw2RoJCO5GY4DouYvb/gepVXheLoewzPseQG9N/vzilrMIjoStE3++zvle4eSurw7XEe76ynI4aq+v7lEyt1x5awiFlFLQbHKIpabnM3eJLym4Szzzc/du7SU+zOXv9UNpECH7IoH/gecURPlN9vdQpeD47yhIFNX0U0QgvID9nENm+yxk/xb+AGAjNfRZuk9qAAAAAElFTkSuQmCC)");
 
-        controlOptions.setElement(mapboxLogo);
+    controlOptions.setElement(Js.cast(mapboxLogo));
 
-        return new Control(controlOptions);
-    }
+    return new Control(controlOptions);
+  }
 
-    /**
-     * Creates a test polygon geometry (triangle).
-     *
-     * @return test polygon geometry (EPSG:3857)
-     */
-    public static Polygon createTestPolygon() {
+  /**
+   * Creates a test polygon geometry (triangle).
+   *
+   * @return test polygon geometry (EPSG:3857)
+   */
+  public static Polygon createTestPolygon() {
 
-        Coordinate[][] coordinates = new Coordinate[1][4];
+    Coordinate[][] coordinates = new Coordinate[1][4];
 
-        Coordinate point1 = new Coordinate(13.36, 52.53);
-        Coordinate point2 = new Coordinate(13.36, 52.51);
-        Coordinate point3 = new Coordinate(13.37, 52.52);
-        Coordinate point4 = new Coordinate(13.36, 52.53);
+    Coordinate point1 = new Coordinate(13.36, 52.53);
+    Coordinate point2 = new Coordinate(13.36, 52.51);
+    Coordinate point3 = new Coordinate(13.37, 52.52);
+    Coordinate point4 = new Coordinate(13.36, 52.53);
 
-        coordinates[0][0] = point1;
-        coordinates[0][1] = point2;
-        coordinates[0][2] = point3;
-        coordinates[0][3] = point4;
+    coordinates[0][0] = point1;
+    coordinates[0][1] = point2;
+    coordinates[0][2] = point3;
+    coordinates[0][3] = point4;
 
-        Coordinate[][] tranformedCoordinates = new Coordinate[coordinates.length][];
+    Coordinate[][] tranformedCoordinates = new Coordinate[coordinates.length][];
 
-        tranformedCoordinates[0] = OLUtil.transform(coordinates[0], DemoConstants.EPSG_4326, DemoConstants.EPSG_3857);
-        return OLFactory.createPolygon(tranformedCoordinates);
+    tranformedCoordinates[0] = OLUtil.transform(coordinates[0], DemoConstants.EPSG_4326, DemoConstants.EPSG_3857);
+    return OLFactory.createPolygon(tranformedCoordinates);
 
-    }
+  }
 
-    public static Base createOsmLayer() {
-        XyzOptions osmSourceOptions = OLFactory.createOptions();
+  public static Base createOsmLayer() {
+    XyzOptions osmSourceOptions = OLFactory.createOptions();
 
-        Osm osmSource = new Osm(osmSourceOptions);
-        LayerOptions osmLayerOptions = OLFactory.createOptions();
-        osmLayerOptions.setSource(osmSource);
+    Osm osmSource = new Osm(osmSourceOptions);
+    LayerOptions osmLayerOptions = OLFactory.createOptions();
+    osmLayerOptions.setSource(osmSource);
 
-        return new Tile(osmLayerOptions);
-    }
+    return new Tile(osmLayerOptions);
+  }
 
 }


### PR DESCRIPTION
To avoid unnecessary dependencies to GWT API, replaced to HandlerRegistration 