### PR TITLE
Fix rotation setter javadoc

### DIFF
--- a/gwt-ol3-client/src/main/java/ol/View.java
+++ b/gwt-ol3-client/src/main/java/ol/View.java
@@ -341,7 +341,7 @@ public class View extends Object {
     public native void setResolution(double resolution);
 
     /**
-     * Get the rotation for this view.
+     * Set the rotation for this view.
      *
      * @param rotation
      *            The rotation of the view in radians.


### PR DESCRIPTION
## Summary
- correct documentation for `View.setRotation`

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*