### PR TITLE
Fix geolocation error alert

### DIFF
--- a/gwt-ol3-demo/src/main/java/com/github/tdesjardins/ol3/demo/client/example/GeolocationExample.java
+++ b/gwt-ol3-demo/src/main/java/com/github/tdesjardins/ol3/demo/client/example/GeolocationExample.java
@@ -139,7 +139,7 @@ public class GeolocationExample implements Example {
 
         geolocation.on("error", (Event event) -> {
 
-            Window.alert("Could't determine location!");
+            Window.alert("Couldn't determine location!");
 
         });
 


### PR DESCRIPTION
## Summary
- fix a typo in the Geolocation example alert message

## Testing
- `mvn -B package -Dmaven.test.skip=true --file pom.xml` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6867ee7fdda0832ab1eff553eb95a136